### PR TITLE
Rec601LumaColorspace -> GRAYColorspace for newer imagemagick/rmagick

### DIFF
--- a/lib/dhash.rb
+++ b/lib/dhash.rb
@@ -1,5 +1,5 @@
 require 'dhash/version'
-require 'RMagick'
+require 'rmagick'
 
 module Dhash extend self
   def hamming(a, b)

--- a/lib/dhash.rb
+++ b/lib/dhash.rb
@@ -8,7 +8,7 @@ module Dhash extend self
 
   def calculate(file, hash_size = 8)
     image = Magick::Image.read(file).first
-    image = image.quantize(256, Magick::Rec601LumaColorspace, Magick::NoDitherMethod, 8)
+    image = image.quantize(256, Magick::GRAYColorspace, Magick::NoDitherMethod, 8)
     image = image.resize!(hash_size + 1, hash_size)
 
     difference = []

--- a/lib/dhash/version.rb
+++ b/lib/dhash/version.rb
@@ -1,3 +1,3 @@
 module Dhash
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
See https://github.com/Nakilon/dhash-vips/issues/16#issuecomment-1100679575

Though note that according to my tests the comparison quality went down a bit, not sure why. Maybe the colorschemes are not really the same, but I suppose there is no way to fix it, it's imagemagick deprecation.